### PR TITLE
Do not crash when attempting to install pod with no supported targets

### DIFF
--- a/lib/cocoapods/installer.rb
+++ b/lib/cocoapods/installer.rb
@@ -338,6 +338,8 @@ module Pod
         end
       end
 
+      raise Informative, "Could not install '#{pod_name}' pod. There is no target that supports it." if specs_by_platform.empty?
+
       @pod_installers ||= []
       pod_installer = PodSourceInstaller.new(sandbox, specs_by_platform, :can_cache => installation_options.clean?)
       @pod_installers << pod_installer

--- a/lib/cocoapods/installer/analyzer/target_inspector.rb
+++ b/lib/cocoapods/installer/analyzer/target_inspector.rb
@@ -159,6 +159,10 @@ module Pod
                   "Unable to determine the platform for the `#{target_definition.name}` target."
           end
 
+          UI.warn "Automatically assigning platform #{name} with version #{deployment_target} " \
+            "on target #{target_definition.name} because no platform was specified. " \
+            "Please specify a platform for this target in your Podfile."
+
           target_definition.set_platform(name, deployment_target)
           Platform.new(name, deployment_target)
         end

--- a/spec/unit/installer/analyzer/target_inspector_spec.rb
+++ b/spec/unit/installer/analyzer/target_inspector_spec.rb
@@ -232,6 +232,8 @@ module Pod
         target_inspector = TargetInspector.new(target_definition, config.installation_root)
         platforms = target_inspector.send(:compute_platform, user_targets)
         platforms.should == Platform.new(:ios, '4.0')
+        UI.warnings.should.include 'Automatically assigning platform ios with version 4.0 on target default because no ' \
+          'platform was specified. Please specify a platform for this target in your Podfile.'
       end
 
       it 'uses the lowest deployment target of the user targets if inferring the platform' do

--- a/spec/unit/installer_spec.rb
+++ b/spec/unit/installer_spec.rb
@@ -540,6 +540,16 @@ module Pod
           UI.output.should.include 'was 1.0'
         end
 
+        it 'raises when it attempts to install pod source with no target supporting it' do
+          spec = fixture_spec('banana-lib/BananaLib.podspec')
+          pod_target = PodTarget.new([spec], [fixture_target_definition], config.sandbox)
+          pod_target.stubs(:platform).returns(:ios)
+          @installer.stubs(:pod_targets).returns([pod_target])
+          should.raise Informative do
+            @installer.send(:create_pod_installer, 'RandomPod')
+          end.message.should.include 'Could not install \'RandomPod\' pod. There is no target that supports it.'
+        end
+
         #--------------------------------------#
 
         describe '#clean' do


### PR DESCRIPTION
closes #6465

Not in love with this fix but this is an edge case overall. These things must be true in order to crash:

- The user has specified a pod at the top level, not within a specific target.
- The invisible 'Pods' target has no platform set so it accepts all pods including transitive deps.
- The platform for the users target in the podfile is automatically inferred or is set explicitly to a version that does not support a pod.

With this change the user will now be warned that the platform was automatically inferred and also provide an informative message that the pod could not be installed.

Cases to repro:

```ruby
source 'https://github.com/CocoaPods/Specs.git'
use_frameworks!
pod 'Lock', '~> 1.28'
# pod 'Auth0', '~> 1.1'

target 'MyOSXApp' do
	platform :osx, '10.10'
end
```

or 

```ruby
source 'https://github.com/CocoaPods/Specs.git'
use_frameworks!
pod 'Lock', '~> 1.28'
target 'MyOSXApp'
```

For the second one to reproduce the Xcode project must set the Base SDK to OSX so its automatically inferred.

I went in circles and circles to figure this out, there is a chance the resolver can probably do a better job here but its an edge case in my opinion.

If the user explicitly specifies the platform for the top level 'Pods' target then things work properly.