### PR TITLE
Prevent multiple script phases from stripping vendored dSYM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
-
+* Prevent multiple script phases from stripping vendored dSYM  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#XXXX](https://github.com/CocoaPods/CocoaPods/pull/XXXX)
 
 ## 1.4.0.beta.2 (2017-10-24)
 

--- a/lib/cocoapods/generator/embed_frameworks_script.rb
+++ b/lib/cocoapods/generator/embed_frameworks_script.rb
@@ -99,17 +99,22 @@ module Pod
           install_dsym() {
             local source="$1"
             if [ -r "$source" ]; then
-              echo "rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --filter \\"- CVS/\\" --filter \\"- .svn/\\" --filter \\"- .git/\\" --filter \\"- .hg/\\" --filter \\"- Headers\\" --filter \\"- PrivateHeaders\\" --filter \\"- Modules\\" \\"${source}\\" \\"${DWARF_DSYM_FOLDER_PATH}\\""
-              rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --filter "- CVS/" --filter "- .svn/" --filter "- .git/" --filter "- .hg/" --filter "- Headers" --filter "- PrivateHeaders" --filter "- Modules" "${source}" "${DWARF_DSYM_FOLDER_PATH}"
-            fi
+              # Copy the dSYM into a the targets temp dir.
+              echo "rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --filter \"- CVS/\" --filter \"- .svn/\" --filter \"- .git/\" --filter \"- .hg/\" --filter \"- Headers\" --filter \"- PrivateHeaders\" --filter \"- Modules\" \"${source}\" \"${DERIVED_FILES_DIR}\""
+              rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --filter "- CVS/" --filter "- .svn/" --filter "- .git/" --filter "- .hg/" --filter "- Headers" --filter "- PrivateHeaders" --filter "- Modules" "${source}" "${DERIVED_FILES_DIR}"
 
-            local basename
-            basename="$(basename -s .framework.dSYM "$source")"
-            binary="${DWARF_DSYM_FOLDER_PATH}/${basename}.framework.dSYM/Contents/Resources/DWARF/${basename}"
+              local basename
+              basename="$(basename -s .framework.dSYM "$source")"
+              binary="${DERIVED_FILES_DIR}/${basename}.framework.dSYM/Contents/Resources/DWARF/${basename}"
 
-            # Strip invalid architectures so "fat" simulator / device frameworks work on device
-            if [[ "$(file "$binary")" == *"Mach-O dSYM companion"* ]]; then
-              strip_invalid_archs "$binary"
+              # Strip invalid architectures so "fat" simulator / device frameworks work on device
+              if [[ "$(file "$binary")" == *"Mach-O dSYM companion"* ]]; then
+               strip_invalid_archs "$binary"
+              fi
+
+              # Move the stripped file into its final destination.
+              echo "rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --filter \"- CVS/\" --filter \"- .svn/\" --filter \"- .git/\" --filter \"- .hg/\" --filter \"- Headers\" --filter \"- PrivateHeaders\" --filter \"- Modules\" \"${DERIVED_FILES_DIR}/${basename}.framework.dSYM\" \"${DWARF_DSYM_FOLDER_PATH}\""
+              rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --filter "- CVS/" --filter "- .svn/" --filter "- .git/" --filter "- .hg/" --filter "- Headers" --filter "- PrivateHeaders" --filter "- Modules" "${DERIVED_FILES_DIR}/${basename}.framework.dSYM" "${DWARF_DSYM_FOLDER_PATH}"
             fi
           }
 


### PR DESCRIPTION
After upgrading to 1.4.0.beta.2 that includes stripping of dSYM architectures we noticed a race condition.

When multiple targets are integrating the same dSYM there is a race that can occur during the `install_dsym` method due to architecture stripping.

This change moves the dSYM in the intermediate files first of the target, strips it and then moves it to the final destination.